### PR TITLE
Buggy Rule ForEachVariablesNotUpdated

### DIFF
--- a/src/Domain/Refactoring/Exercise.hs
+++ b/src/Domain/Refactoring/Exercise.hs
@@ -52,7 +52,7 @@ makeRefactorExercise refExInput settings = addReady $ emptyExercise
         canBeRestarted = true,
         examples       = examplesWithDifficulty [(Medium, startCM refExInput)],
         constraints    = map c2 (testCases refExInput), -- check in diagnose
-        extraRules     = [use buggyEqualsTrue, use buggyCollapseIfR, use incrementAssignBuggy, use compoundSubtractionBuggy, use decrementAssignBuggy, use compoundAdditionBuggy]
+        extraRules     = [use buggyEqualsTrue, use buggyCollapseIfR, use incrementAssignBuggy, use compoundSubtractionBuggy, use decrementAssignBuggy, use compoundAdditionBuggy, use forToForeachBuggy]
       }
     where
         addReady e = e { ready = predicate (stepsLeft e) }

--- a/src/Domain/Refactoring/Rules/BuggyRules.hs
+++ b/src/Domain/Refactoring/Rules/BuggyRules.hs
@@ -1,4 +1,4 @@
-module Domain.Refactoring.Rules.BuggyRules(incrementAssignBuggy, decrementAssignBuggy, compoundSubtractionBuggy, compoundAdditionBuggy) where
+module Domain.Refactoring.Rules.BuggyRules(incrementAssignBuggy, decrementAssignBuggy, compoundSubtractionBuggy, compoundAdditionBuggy, forToForeachBuggy) where
 
 import Domain.Parsers.JavaParser
 
@@ -36,3 +36,7 @@ compoundSubtractionBuggy = buggy $ ruleRewrite $ makeRewriteRule "compoundSubtra
 compoundAdditionBuggy :: Rule Statement
 compoundAdditionBuggy = buggy $ ruleRewrite $ makeRewriteRule "compoundAdditionBuggy" $
   \x n -> ExprStat (x .=. (x .+. n)) :~> ExprStat (x .=. (Prefixed Plus n))
+
+forToForeachBuggy :: Rule Statement
+forToForeachBuggy = buggy $ ruleRewrite $ makeRewriteRule "forToForeachBuggy" $
+  \i arr b -> For (ForInitDecls IntType [Assignment Assign (IdExpr i) (LiteralExpr (IntLiteral 0))]) [Infixed Less (IdExpr i) (Property arr (Identifier {name = "length"}))] [Postfixed Incr (IdExpr i)] b :~> ForEach IntType i (IdExpr arr) b

--- a/src/Domain/Refactoring/Rules/BuggyRules.hs
+++ b/src/Domain/Refactoring/Rules/BuggyRules.hs
@@ -44,7 +44,7 @@ forToForeachBuggy = buggy $ ruleRewrite $ makeRewriteRule "forToForeachBuggy" $
   \i arr b -> For (ForInitDecls IntType [Assignment Assign (IdExpr i) (LiteralExpr (IntLiteral 0))]) [Infixed Less (IdExpr i) (Property arr (Identifier {name = "length"}))] [Postfixed Incr (IdExpr i)] b :~> ForEach IntType i (IdExpr arr) b
 -}
 
--- | 
+-- | Buggy rule for incorrectly transforming an for loop into a foreach by forgetting to update the body. This rule will only work if the body in both the for and foreach are the same.
 forToForeachBuggy :: Rule Statement
 forToForeachBuggy = buggy $ makeRule "forToForeachViewBuggy" f'
   where

--- a/src/Domain/Syntax.hs
+++ b/src/Domain/Syntax.hs
@@ -51,6 +51,13 @@ data DataType =
     |   DoubleType
     deriving (Data, Typeable, Eq, Show, Ord, Read)
 
+-- | A list of constructors in `DataType`, going one level deep (so no multi-dimentional arrays)
+allDataTypes :: [DataType]
+allDataTypes = simple ++ arrays
+  where
+    simple = [BoolType, IntType, StringType, DoubleType]
+    arrays = map ArrayType simple
+
 data Literal = 
         Null
     |   IntLiteral      Int

--- a/src/Test/Domain/Refactoring/Rules/BuggyRules.hs
+++ b/src/Test/Domain/Refactoring/Rules/BuggyRules.hs
@@ -37,3 +37,8 @@ test_compoundAdditionBuggy = assertJustEq after $ apply compoundAdditionBuggy be
     before = ExprStat (Assignment Assign (IdExpr (Identifier {name = "x"})) (Infixed Addition (IdExpr (Identifier {name = "x"})) (LiteralExpr (IntLiteral 3))))
     after = ExprStat (Assignment Assign (IdExpr (Identifier {name = "x"})) (Prefixed Plus (LiteralExpr (IntLiteral 3))))
 
+test_forToForeachBuggy :: Assertion
+test_forToForeachBuggy = assertJustEq after $ apply forToForeachBuggy before
+  where
+    before = For (ForInitDecls IntType [Assignment Assign (IdExpr (Identifier {name = "i"})) (LiteralExpr (IntLiteral 0))]) [Infixed Less (IdExpr (Identifier {name = "i"})) (Property (Identifier {name = "items"}) (Identifier {name = "length"}))] [Postfixed Incr (IdExpr (Identifier {name = "i"}))] (Block 0 [ExprStat (Call (Identifier {name = "print"}) [ArrayAcc (Identifier {name = "items"}) (IdExpr (Identifier {name = "i"}))])])
+    after = ForEach BoolType (Identifier {name = "i"}) (IdExpr (Identifier {name = "items"})) (Block 0 [ExprStat (Call (Identifier {name = "print"}) [ArrayAcc (Identifier {name = "items"}) (IdExpr (Identifier {name = "i"}))])])


### PR DESCRIPTION
This pull request adds a buggy rule for the refactoring misconception L1. ForEachVariablesNotUpdated. It currently matches for any simple type of loop (over lists or over lists of lists) and only works if the complete body remains unchanged. 

![](https://stanisic.nl/EL.png)

#### Acceptance Criteria
- [x] The example from refactoring misconceptions must match:

Before:
```
public static int countEven(int [] values) {
    int count = 0;
    for (int i = 0; i < values.length; i++) {
        if (values[i] % 2 == 0) {
            count += 1;
        }
    }
    return count;
}
```

After:
```
public static int countEven(int [] values) {
    int count = 0;
    for (int i : values) {
        if (values[i] % 2 == 0) {
            count += 1;
        }
    }
    return count;
}
```


#### Definition of Done

- [x] Unit tests or quickcheck tests are written.
- [x] New runs of automated testing report don't show additional failing tests.
- [x] The project builds correctly.
- [x] Code fulfills acceptance criteria.
- [x] Code follows the ‘Good Programming Practice’ from Haskell Wiki (2022).
- [x] Variable, function and type names follow the naming conventions from Haskell Wiki (2022).
- [x] Inline documentation in the code is present.
- [x] Branch names follow the GitFlow standard (Datasift, 2012).
- [x] Commit messages are written in English and follow the best practices of Beams (2020).