### PR TITLE
Regression tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           RCLONE_CONFIG: ${{ secrets.RCLONE_CONFIG }}
         run: |
-          sudo apt install -qqy rclone
+          sudo apt install -y rclone &>/dev/null
 
           # Download the base version of rpt to compare to
           wget --quiet https://github.com/${{ github.repository }}/releases/download/v1.1.0/rpt --output-document base-rpt && chmod +x base-rpt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Setup
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: sudo .docker/setup.sh
+        run: |
+          sudo .docker/setup.sh
 
       - name: Build
         run: |
@@ -35,6 +36,25 @@ jobs:
           cp scripts/ref.txt ref.txt
           tar czf rpt-web.tar.gz www
           tar czf rpt-cgi.tar.gz exercises ref.txt rpt login
+
+      - name: Regression Test
+        env:
+          RCLONE_CONFIG: ${{ secrets.RCLONE_CONFIG }}
+        run: |
+          sudo apt install -qqy rclone
+
+          # Download the base version of rpt to compare to
+          wget --quiet https://github.com/${{ github.repository }}/releases/download/v1.1.0/rpt --output-document base-rpt && chmod +x base-rpt
+
+          # Setup rsync for onedrive access
+          echo "$RCLONE_CONFIG" | base64 -d > rclone.conf
+          
+          # Get database from onedrive and run tests
+          rclone --config rclone.conf copy OneDrive:rpt/requests-rpt-cleaned-enhanced.db .
+          stack runhaskell RegressionTests.hs -- $PWD/requests-rpt-cleaned-enhanced.db $PWD/base-rpt $PWD/rpt
+
+          # Remove files
+          rm -rf rclone.conf requests-rpt-cleaned-enhanced.db
 
       - name: Artifact
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ flycheck_*.el
 .dir-locals.el
 /network-security.data
 
+# rpt
+/X*.java
+/input.json

--- a/RegressionTests.hs
+++ b/RegressionTests.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+module RegressionTests where
+
+import Database.HDBC.Sqlite3
+import Database.HDBC
+import System.IO
+import System.Environment
+import System.Exit
+import System.Process
+import Data.Aeson
+import Data.Aeson.Types
+import Data.Maybe
+import qualified Data.ByteString.Lazy.UTF8 as BLU
+import qualified Data.HashMap.Strict as HM
+import Data.Text (Text)
+import qualified Data.Text.IO as TIO
+import Data.List
+
+status_list :: [Text]
+status_list = ["", "syntaxerror", "notequiv", "similar", "correct", "expected", "buggy"]
+
+getScore :: Maybe Text -> Int
+getScore status = fromMaybe 0 $ elemIndex (fromMaybe "" status) status_list
+
+loadFromDB :: String -> String -> IO [[SqlValue]]
+loadFromDB dbPath sql = do
+    conn <- connectSqlite3 dbPath
+    dat <- quickQuery' conn sql []
+    disconnect conn
+    return dat
+
+getInputOutput :: String -> IO [(String, String)]
+getInputOutput database = do
+  results <- loadFromDB database "select input, output from requests where service = 'diagnoser';"
+  return $ map (\(x:y:_) -> (fromSql x, fromSql y)) results 
+
+runRpt :: String -> String -> IO String
+runRpt file input = do
+  _ <- writeFile "input.json" input
+  readProcess file ["--file=input.json"] ""
+
+getStatus :: String -> Maybe Text
+getStatus result = do
+  obj <- (decode $ BLU.fromString result :: Maybe Object)
+  status <- (parseMaybe (\o -> o .: "result") obj :: Maybe Object)
+  return $ fst $ head $ HM.toList status
+
+processEntry :: String -> String -> Int -> [(String, String)] -> IO Int
+processEntry base compare dif [] = return dif
+processEntry base compare dif ((input, _):xs) = do
+
+  old_output <- runRpt base input
+  new_output <- runRpt compare input
+
+  let new_status = getStatus new_output
+  let old_status = getStatus old_output
+
+  let new_points = getScore new_status
+  let old_points = getScore old_status
+
+  let difference = new_points - old_points
+  
+  if difference >= 0
+    then processEntry base compare (dif + difference) xs
+    else do
+      putStrLn "Test case failed!"
+      print old_status
+      print old_points
+
+      print new_status
+      print new_points
+      
+      putStrLn input
+      putStrLn old_output
+      putStrLn new_output
+      
+      return 0  
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [database, base, compare] -> do
+      items <- getInputOutput database
+      score <- processEntry base compare 0 items
+      putStrLn $ "New score: " ++ show score
+      return ()
+    _ -> do
+      name <- getProgName
+      hPutStrLn stderr $ "usage: " ++ name ++ " <database> <base> <compare>"
+      hPutStrLn stderr $ "  database: path to sqlite3 database with data to compare against"
+      hPutStrLn stderr $ "  base:     path to cgi executable of the base system"
+      hPutStrLn stderr $ "  compare:  path to cgi executable of the system to compare against"
+      exitFailure


### PR DESCRIPTION
This pull request adds automated regression testing to the CI. This is being done as described in the testing strategy:

- Replay diagnoseR service calls from the experiment logs
- Compare results between the two calls, and require the same or a better diagnosis type

Currently this is implemented in a very simple manner: Both versions of the tutor are called, and the results compared according to this hierarchy: `syntaxerror`, `notequiv`, `similar`, `correct`, `expected`, `buggy`. There are about 70.000 diagnoseR service calls in the log so this means that for every test 140.000 calls are made in total. 

The CI then runs this test on the base version (or first release, v1.1.0) and the currently build version, and either:

- Gives a score indicating how much better the compared tutor is to the base version. This is the combined increase in diagnosis type. Currently you can find this score in the CI logs, under the step Regression Test.
- Fails on a testcase where the old tutor performed better than the previous one. Currently the tests will fail if even 1 of these cases is present. This will also fail the CI job.

Future work would include caching the results of the base compare as these are the same for every time the CI runs, and this would also result in a big speed increase. 

#### Acceptance Criteria

- [x] Results of the current system are compared against a benchmark
- [x] For this benchmark the logging data collected from the experiment with students will be used
- [x] Due to the sensitivity of this data the CI will pull this in from OneDrive
- [x] Foreign pull request cannot access this data.

#### Definition of Done

- [x] Unit tests or quickcheck tests are written.
- [x] New runs of automated testing report don't show additional failing tests.
- [x] The project builds correctly.
- [x] Code fulfills acceptance criteria.
- [x] Code follows the ‘Good Programming Practice’ from Haskell Wiki (2022).
- [x] Variable, function and type names follow the naming conventions from Haskell Wiki (2022).
- [x] Inline documentation in the code is present.
- [x] Branch names follow the GitFlow standard (Datasift, 2012).
- [x] Commit messages are written in English and follow the best practices of Beams (2020).