### PR TITLE
Switch build system from stack to cabal

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,3 +1,10 @@
 FROM ubuntu:20.04 AS builder
+RUN apt update; apt install -y sudo
+RUN useradd -u 1000 -m user; \
+    usermod -aG sudo user
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER user
+ENV USER=user
+ENV SHELL=/bin/bash
 COPY .docker/setup.sh /tmp
 RUN /tmp/setup.sh

--- a/.docker/Dockerfile.runner
+++ b/.docker/Dockerfile.runner
@@ -2,23 +2,25 @@ FROM rpt-builder as builder
 USER user
 WORKDIR /home/user
 ENV GHCUP_INSTALL_BASE_PREFIX=/opt/ghcup
+RUN mkdir rpt
 
 # Create an empty projecr
-RUN bash -ic "stack new rpt; exit"
+#RUN bash -ic "stack new rpt; exit"
 WORKDIR /home/user/rpt
 # We need *some* content here to trick cabal into building the empty project
-RUN rm package.yaml; \
-    mkdir -p src/Test; \
+RUN mkdir -p src/Test; \
     echo 'main = putStrLn "Hello, world!"' > src/Main.hs; \
-    echo 'main = putStrLn "Hello, world!"' > src/Test/IPTTests.hs;
+    echo 'main = putStrLn "Hello, world!"' > src/Test/Tests.hs;
 
 # Build it, and by doing so cache the libraries into the docker image layer
-COPY --chown=user rpt.cabal stack.yaml ./
-RUN bash -ic "stack build; exit"
+COPY --chown=user rpt.cabal cabal.project ./
+RUN bash -ic "cabal build; exit"
 
 # Now we can copy in our own code and build that. If we change anything here we won't have to rebuild all the dependencies every time.
 COPY --chown=user ./src ./src
-RUN bash -ic "stack build; exit"
+RUN bash -ic "cabal build; exit"
+# No globbing in the docker COPY so we do it here
+RUN find . -name rpt -type f -exec cp {} rpt \;
 
 # Switch to apache2 image and lose the haskell toolchain
 FROM httpd:bullseye as runner
@@ -29,7 +31,7 @@ RUN apt update; apt install -y libsqlite3-dev zlib1g-dev
 # Copy in frontend and rpt cgi
 RUN rm -rf /usr/local/apache2/htdocs/*
 COPY ./www /usr/local/apache2/htdocs
-COPY --from=builder /home/user/rpt/.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/rpt/rpt /usr/local/apache2/cgi-bin/rpt
+COPY --from=builder /home/user/rpt/rpt /usr/local/apache2/cgi-bin/rpt
 COPY ./.docker/login /usr/local/apache2/cgi-bin/login
 COPY ./scripts/ref.txt /usr/local/apache2/cgi-bin/ref.txt
 RUN chown -R daemon /usr/local/apache2/cgi-bin

--- a/.docker/setup.sh
+++ b/.docker/setup.sh
@@ -2,38 +2,23 @@
 
 # Make sure we run noninteractive and skip tzdata config
 export DEBIAN_FRONTEND=noninteractive
-ln -fs /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime
+sudo ln -fs /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime
 
 # Install GHCup dependencies
-apt update
-apt install -y libsqlite3-dev zlib1g-dev wget pkg-config g++ gcc \
-               libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev \
-               git gnupg netbase curl build-essential libgmp10 \
-               libncurses-dev libncurses5 libtinfo5 sudo
+sudo apt update
+sudo apt install -y libsqlite3-dev zlib1g-dev wget pkg-config g++ gcc \
+                    libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev \
+                    git gnupg netbase curl build-essential libgmp10 \
+                    libncurses-dev libncurses5 libtinfo5 sudo
 
 # Configure GHCup
 export BOOTSTRAP_HASKELL_GHC_VERSION=8.6.5
 export BOOTSTRAP_HASKELL_NONINTERACTIVE=true
 export BOOTSTRAP_HASKELL_ADJUST_BASHRC=true
 
-
-# Make sure we have an user with uid 100
-USER_ID=1000
-id $USER_ID
-if [ $? -ne 0 ]; then
-  useradd -u $USER_ID -m user
-fi
-
-# Help sudo -E along a little
-export USER="$(id -un $USER_ID)"
-export HOME="$(eval echo ~$USER)"
-export SHELL=/bin/bash
-export TMPDIR=/tmp
-cd $HOME
-
 export GHCUP_INSTALL_BASE_PREFIX=/opt/ghcup
-mkdir -p $GHCUP_INSTALL_BASE_PREFIX
-chown -R $USER:$USER $GHCUP_INSTALL_BASE_PREFIX
+sudo mkdir -p $GHCUP_INSTALL_BASE_PREFIX
+sudo chown -R $USER:$USER $GHCUP_INSTALL_BASE_PREFIX
 
 # Install GHCup
-curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sudo -Eu $USER sh
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org |  sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,23 @@ jobs:
         with:
           path: |
             /opt/ghcup
-            /home/runner/.stack
-          key: ${{ runner.os }}-build-${{ hashFiles('stack.yaml.lock') }}
+            /home/runner/.cabal
+            /home/runneradmin/.cabal
+            /home/runner/.bashrc
+            /home/runneradmin/.bashrc
+          key: ${{ runner.os }}-build-${{ hashFiles('cabal.project') }}-${{ hashFiles('rpt.cabal') }}
 
       - name: Setup
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          sudo .docker/setup.sh
+          export SHELL=/bin/bash
+          .docker/setup.sh
 
       - name: Build
         run: |
-          stack build
+          bash -ci "cabal build; exit"
 
-          cp .stack-work/dist/*/*/build/rpt/rpt rpt
+          find . -name rpt -type f -exec cp {} rpt \;
           cp .docker/login login
           chmod +x rpt
           cp scripts/ref.txt ref.txt
@@ -51,10 +55,11 @@ jobs:
           
           # Get database from onedrive and run tests
           rclone --config rclone.conf copy OneDrive:rpt/requests-rpt-cleaned-enhanced.db .
-          stack runhaskell RegressionTests.hs -- $PWD/requests-rpt-cleaned-enhanced.db $PWD/base-rpt $PWD/rpt
+          ./RegressionTests.hs $PWD/requests-rpt-cleaned-enhanced.db $PWD/base-rpt $PWD/rpt
 
           # Remove files
           rm -rf rclone.conf requests-rpt-cleaned-enhanced.db
+          unset RCLONE_CONFIG
 
       - name: Artifact
         uses: actions/upload-artifact@v3

--- a/RegressionTests.hs
+++ b/RegressionTests.hs
@@ -1,5 +1,9 @@
+#!/usr/bin/env cabal
+{- cabal:
+build-depends: base, HDBC-sqlite3, HDBC, process, text, aeson, unordered-containers, utf8-string
+-}
 {-# LANGUAGE OverloadedStrings #-}
-module RegressionTests where
+module Main where
 
 import Database.HDBC.Sqlite3
 import Database.HDBC
@@ -8,6 +12,8 @@ import System.Environment
 import System.Exit
 import System.Process
 import Data.Aeson
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Key as K
 import Data.Aeson.Types
 import Data.Maybe
 import qualified Data.ByteString.Lazy.UTF8 as BLU
@@ -49,7 +55,7 @@ getStatus :: String -> Text
 getStatus result = fromMaybe "" $ do
   obj <- (decode $ BLU.fromString result :: Maybe Object)
   status <- (parseMaybe (\o -> o .: "result") obj :: Maybe Object)
-  return $ fst $ head $ HM.toList status
+  return $ K.toText $ fst $ head $ KM.toList status
   
 -- | Process a list of requests by comparing `base` and `compare` (two paths to rpt executables)
 -- `diff` and `count` start off being `0`

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,17 @@
+packages: .
+compiler: ghc
+with-compiler: ghc-8.6.5
+
+documentation: True
+haddock-executables: True
+
+source-repository-package
+    type: git
+    location: https://github.com/ideas-edu/ideas.git
+    tag: 13bc304e78aa78d0dec6e0e5e9e7a31aa6715390
+
+source-repository-package
+    type: git
+    location: https://github.com/bgamari/hdbc-sqlite3.git
+    tag: 1562ea5b6b97309c86d2fc5ae172a530f943c86c
+

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -3,7 +3,7 @@
 
 # Containers
 
-On the next page, in figure \ref{containers}, an overview of the different containers is given. This overview is not complete: it only contains the parts of the refactor tutor that are relevant to this project.
+On the next page, in the figure below an overview of the different containers is given. This overview is not complete: it only contains the parts of the refactor tutor that are relevant to this project.
 
 The tutor consists of a Domain Reasoner, a datatype from the Ideas framework. This Domain Reasoner contains all necessary configuration for the Ideas framework to generate feedback. This configurations most importantly contains a list of exercises: this is what the student works on. An exercise is defined by the following properties:
 

--- a/docs/global-architecture.md
+++ b/docs/global-architecture.md
@@ -3,7 +3,7 @@
 
 # Global Architecture
 
-The tutor is build up from a server-client architecture. The client, a webpage, communicates with the server over HTTP requests to a single CGI endpoint. Figure \ref{system} shows this in more detail.
+The tutor is build up from a server-client architecture. The client, a webpage, communicates with the server over HTTP requests to a single CGI endpoint. The figure below shows this in more detail.
 
 ```plantuml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/d193a84febce699caf236e3115dbed5ac8418397/C4_Container.puml

--- a/docs/instructions-apache2.md
+++ b/docs/instructions-apache2.md
@@ -30,7 +30,6 @@ Finally, to enable or disable the login screen, use one of the following options
 SetEnv LOGIN_ENABLED false
 ```
 
-\clearpage
 After all these steps you should have something similar to the following:
 
 ```

--- a/docs/instructions-docker.md
+++ b/docs/instructions-docker.md
@@ -1,7 +1,7 @@
 # Installation Instructions Docker
 If you want to get started using docker, make sure you have docker installed first.
 
-You can use the `stephanstanisic/refactor-tutor` image on docker hub to deploy the refactor tutor together with a preconfigured apache2 webserver.
+You can use the `refactortutor/refactor-tutor` image on docker hub to deploy the refactor tutor together with a pre-configured apache2 webserver.
 To do so, you will first need to create a folder with exercises. These have the following structure:
 
 ```
@@ -20,7 +20,7 @@ docker run \
   -p 8080:80 \
   -v "$(pwd)/exercises:/usr/local/apache2/cgi-bin/exercises" \
   -e "RPT_LOGIN_ENABLED=false" \
-  stephanstanisic/refactor-tutor
+  refactortutor/refactor-tutor
 ```
 
 Alternatively, you can use the following `docker-compose.yml` file:
@@ -30,7 +30,7 @@ version: '3'
 
 services:
   refactor-tutor:
-    image: stephanstanisic/refactor-tutor
+    image: refactortutor/refactor-tutor
     ports:
     - "8080:80"
     volumes:

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -37,7 +37,7 @@ cd2 -d-> hub : Upload artifact
 @enduml
 ```
 
-![Deploying a new release](images/release-flow.png)
+In order to release a new version of the refactor tutor, only a [new release has to be tagged](https://github.com/ideas-edu/refactor-tutor/releases/new) on github. It is important that the tag name for this (in the dropdown choose tag, type in a new one to create a new tag) follows semantic versioning in the following format: `v0.0.0`.
 
 ## Considerations for running in the cloud
 

--- a/docs/setup-development-environment.md
+++ b/docs/setup-development-environment.md
@@ -1,6 +1,6 @@
 # Setting up the development environment
 
-Development uses both docker and stack. Stack is used to develop locally, testing and running parts of the code in GHCi. Docker is used for deployment, and for testing the software locally.
+Development uses both docker and cabal. Cabal is used to develop locally, testing and running parts of the code in GHCi. Docker is used for deployment, and for testing the software locally.
 
 ## Installing
 
@@ -8,22 +8,24 @@ Installation instructions differ slightly for every platform, but building is su
 
 ### Windows
 
-1. Install Windows Subsystem for Linux (WSL) version 2 or higher, and install a linux distribution (for example ubuntu). Example guide: <https://dev.to/luckierdodge/how-to-install-and-use-docker-in-wsl2-217l>
-2. Install docker inside the WSL container. Do not install Docker Desktop for Windows, you want to use the docker installations from the WSL virtual machine. Guide for ubuntu: <https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository>
-3. Install GHCup in WSL, a bootstrapping tool that manages ghc, cabal and stack. During installation you will be prompted to install stack, answer `Y`. You will also be asked to configure stack to use GHCup, also answer `Y` here. GHCup can be found here: <https://www.haskell.org/ghcup/install/>
+1. Install Docker Desktop for Windows. <https://www.docker.com/products/docker-desktop/>
+2. Install GHCup, a bootstrapping tool that manages ghc and cabal. GHCup can be found here: <https://www.haskell.org/ghcup/install/>.
+3. Run `ghcup tui`, and install ghc version `8.6.5`. Select this version (two checkmarks).
 4. Clone the repository using git: `git clone git@github.com:ideas-edu/refactor-tutor.git`. You might need to generate and add a ssh key for this to work from WSL. Run `ssh-keygen`, and add the contents of `~/.ssh/id_rsa.pub` to <https://github.com/settings/keys>.
 
 ### Linux
 
 1. Install docker. Guide for ubuntu: <https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository>
-2. Install GHCup, a bootstrapping tool that manages ghc, cabal and stack. During installation you will be prompted to install stack, answer `Y`. You will also be asked to configure stack to use GHCup, also answer `Y` here. GHCup can be found here: <https://www.haskell.org/ghcup/install/>
-3. Clone the repository using git: `git clone git@github.com:ideas-edu/refactor-tutor.git`.
+2. Install GHCup, a bootstrapping tool that manages ghc and cabal. GHCup can be found here: <https://www.haskell.org/ghcup/install/>.
+3. Run `ghcup tui`, and install ghc version `8.6.5`. Select this version (two checkmarks).
+4. Clone the repository using git: `git clone git@github.com:ideas-edu/refactor-tutor.git`.
 
 ### MacOS
 
 1. Install docker. Guide for MacOS: <https://docs.docker.com/desktop/install/mac-install/>
-2. Install GHCup, a bootstrapping tool that manages ghc, cabal and stack. During installation you will be prompted to install stack, answer `Y`. You will also be asked to configure stack to use GHCup, also answer `Y` here. GHCup can be found here: <https://www.haskell.org/ghcup/install/>
-3. Clone the repository using git: `git clone git@github.com:ideas-edu/refactor-tutor.git`.
+2. Install GHCup, a bootstrapping tool that manages ghc and cabal. GHCup can be found here: <https://www.haskell.org/ghcup/install/>.
+3. Run `ghcup tui`, and install ghc version `8.6.5`. Select this version (two checkmarks).
+4. Clone the repository using git: `git clone git@github.com:ideas-edu/refactor-tutor.git`.
 
 ## Running
 
@@ -32,16 +34,28 @@ Installation instructions differ slightly for every platform, but building is su
 To build the tutor locally, run
 
 ```bash
-stack build
+cabal build
 ```
 
 To clear build files and force a rebuild use
 
 ```bash
-stack clean
+cabal clean
 ```
 
-To run unit and property tests use
+To enter a ghci repl, usr
+
+```bash
+cabal repl
+```
+
+To run unit and property tests, make sure `htfpp` is in the path, then use
+
+```bash
+cabal test
+```
+
+If you can't install `htfpp` then try stack, it comes with htfpp pre-installed:
 
 ```bash
 stack test
@@ -50,7 +64,7 @@ stack test
 To run regression tests use
 
 ```bash
-stack runhaskell RegressionTests.hs -- \
+./RegressionTests.hs \
   /path/to/requests-rpt-cleaned-enhanced.db \
   /path/to/base.cgi \
   /path/to/compare.cgi

--- a/docs/updating-the-wiki.md
+++ b/docs/updating-the-wiki.md
@@ -1,0 +1,3 @@
+# Updating the Wiki
+
+If you want to edit this wiki, do so by changing the files in the main repo's `docs/` folder. Contents of these wiki pages are generated from that folder, and overwritten.

--- a/rpt.cabal
+++ b/rpt.cabal
@@ -10,7 +10,7 @@ common deps
                    containers,
                    uniplate,
                    time,
-                   wl-pprint,
+                   wl-pprint == 1.2.1,
                    array,
                    pretty,
                    parsec,

--- a/src/Domain/Refactoring/Services.hs
+++ b/src/Domain/Refactoring/Services.hs
@@ -92,7 +92,7 @@ diagnoseR state new =
 
             -- Similar?
             -- moved for empty exercises
-            | similarity ex (stateContext state) parsedNew = return $ Similar (finished state) state
+            | similarity ex (stateContext state) parsedNew = return $ Similar (finished state) state Nothing
 
             -- Recognised step?
             | isJust (expected parsedNew)  =
@@ -160,7 +160,7 @@ diagnoseTextRold script old ctx = do
       Buggy _ _       -> (False, output diagnosis, old, False, "buggy")
       NotEquivalent _ -> (False, output diagnosis, old, False, "notequivalent")
       Expected r s _  -> (True , output diagnosis, s, r, "expected") 
-      Similar r s     -> (True , output diagnosis, s, r, "similar")
+      Similar r s _   -> (True , output diagnosis, s, r, "similar")
       Detour r s _ _  -> (True , output diagnosis, s, r, "detour")
       Correct r s     -> (False, succMsg, s, r, "correct")
       Unknown r s     -> (False, gaveUpMsg, s, r, "unknown")

--- a/src/FPTutor/Diagnose.hs
+++ b/src/FPTutor/Diagnose.hs
@@ -59,7 +59,7 @@ deepdiagnose s new
    -- Is the submitted term (very) similar to the previous one? 
    | similarity ex (stateContext state) new =
         -- If yes, report this
-        Similar (finished state) state
+        Similar (finished state) state Nothing
 
   -- old fp
    -- Was the submitted term expected by the strategy?

--- a/src/FPTutor/Services.hs
+++ b/src/FPTutor/Services.hs
@@ -85,7 +85,7 @@ feedbacktextdeep script old ctx =
       Buggy _ _       -> (False, output, old, False, "buggy")
       NotEquivalent _ -> (False, output, old, False, "notequivalent")
       Expected r s _  -> (True , output, s, r, "expected") 
-      Similar r s     -> (True , output, s, r, "similar")
+      Similar r s _   -> (True , output, s, r, "similar")
       Detour r s _ _  -> (True , output, s, r, "detour")
       Correct r s     -> (False, succMsg, s, r, "correct")
       Unknown r s     -> (False, gaveUpMsg, s, r, "unknown")

--- a/src/Test/TestUtils.hs
+++ b/src/Test/TestUtils.hs
@@ -90,7 +90,7 @@ newState' diagnosis =
    case diagnosis of
       Buggy _ _        -> Nothing
       NotEquivalent _  -> Nothing
-      Similar  _ s     -> Just s
+      Similar  _ s _   -> Just s
       WrongRule _ s _  -> Just s
       Expected _ s _   -> Just s
       Detour   _ s _ _ -> Just s

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,6 @@ extra-deps:
   commit: 0285358d4d703d9daf2c65baa2c2d3d782b344df
 - git: https://github.com/bgamari/hdbc-sqlite3.git
   commit: 1562ea5b6b97309c86d2fc5ae172a530f943c86c
-- QuickCheck-2.11.3@sha256:5e8e84718b2a47ba2986732adf9fd8888f2bef965854ed3a0beb14e8da938389,5499
 - streaming-commons-0.1.19@sha256:d11aea24fbf6dc95594f3213b8985726baf0abf870e49d6b3f5ac60d4e4f3125,5333
 - wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
+- QuickCheck-2.11.3@sha256:5e8e84718b2a47ba2986732adf9fd8888f2bef965854ed3a0beb14e8da938389,5499

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,8 +5,8 @@ packages:
 
 extra-deps:
 - ConfigFile-1.1.4
-- git: https://github.com/StephanStanisic/ideas.git
-  commit: 0285358d4d703d9daf2c65baa2c2d3d782b344df
+- git: https://github.com/ideas-edu/ideas.git
+  commit: 13bc304e78aa78d0dec6e0e5e9e7a31aa6715390
 - git: https://github.com/bgamari/hdbc-sqlite3.git
   commit: 1562ea5b6b97309c86d2fc5ae172a530f943c86c
 - streaming-commons-0.1.19@sha256:d11aea24fbf6dc95594f3213b8985726baf0abf870e49d6b3f5ac60d4e4f3125,5333

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,16 +12,16 @@ packages:
   original:
     hackage: ConfigFile-1.1.4
 - completed:
-    commit: 0285358d4d703d9daf2c65baa2c2d3d782b344df
-    git: https://github.com/StephanStanisic/ideas.git
+    commit: 13bc304e78aa78d0dec6e0e5e9e7a31aa6715390
+    git: https://github.com/ideas-edu/ideas.git
     name: ideas
     pantry-tree:
-      sha256: 7da73d8e5d80dc81c8c613434dc4ba51ae5a158cdb6fe9e60476caae37b31e77
-      size: 9710
-    version: '1.8'
+      sha256: 2a7162272158751550727317d46570e787c6c622e1239d6b03a4781dca6e7054
+      size: 9940
+    version: 1.8.1
   original:
-    commit: 0285358d4d703d9daf2c65baa2c2d3d782b344df
-    git: https://github.com/StephanStanisic/ideas.git
+    commit: 13bc304e78aa78d0dec6e0e5e9e7a31aa6715390
+    git: https://github.com/ideas-edu/ideas.git
 - completed:
     commit: 1562ea5b6b97309c86d2fc5ae172a530f943c86c
     git: https://github.com/bgamari/hdbc-sqlite3.git

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -34,13 +34,6 @@ packages:
     commit: 1562ea5b6b97309c86d2fc5ae172a530f943c86c
     git: https://github.com/bgamari/hdbc-sqlite3.git
 - completed:
-    hackage: QuickCheck-2.11.3@sha256:5e8e84718b2a47ba2986732adf9fd8888f2bef965854ed3a0beb14e8da938389,5499
-    pantry-tree:
-      sha256: b2865f6c8f139e8429d287b3e7179e8ca4ef2ab97c5b547657ca8f49276a801f
-      size: 1862
-  original:
-    hackage: QuickCheck-2.11.3@sha256:5e8e84718b2a47ba2986732adf9fd8888f2bef965854ed3a0beb14e8da938389,5499
-- completed:
     hackage: streaming-commons-0.1.19@sha256:d11aea24fbf6dc95594f3213b8985726baf0abf870e49d6b3f5ac60d4e4f3125,5333
     pantry-tree:
       sha256: 59dd57726a2cb299b7d62b3bfb6694b3a50aa444e447ad0099809bdbd82a265a
@@ -54,6 +47,13 @@ packages:
       size: 221
   original:
     hackage: wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
+- completed:
+    hackage: QuickCheck-2.11.3@sha256:5e8e84718b2a47ba2986732adf9fd8888f2bef965854ed3a0beb14e8da938389,5499
+    pantry-tree:
+      sha256: b2865f6c8f139e8429d287b3e7179e8ca4ef2ab97c5b547657ca8f49276a801f
+      size: 1862
+  original:
+    hackage: QuickCheck-2.11.3@sha256:5e8e84718b2a47ba2986732adf9fd8888f2bef965854ed3a0beb14e8da938389,5499
 snapshots:
 - completed:
     sha256: f761fe419a1a44fc3ef47f5bfb1853304d13320fc72b45d2798c08d21dabc23c


### PR DESCRIPTION
After discussing with Bastiaan, we don't actually need stack for anything anymore (as we can figure out the correct versions from the lts stackage snapshot). As stack makes developing on Windows hard, this pull request changes the build system over to cabal only. The wiki has been updated with relevant new commands and installation instructions.